### PR TITLE
Replace with Random.Shared from .NET 6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Random/issues/53
-Your prepared branch: issue-53-d8b25e8f
-Your prepared working directory: /tmp/gh-issue-solver-1757712450083
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Random/issues/53
+Your prepared branch: issue-53-d8b25e8f
+Your prepared working directory: /tmp/gh-issue-solver-1757712450083
+
+Proceed.

--- a/csharp/Platform.Random/Platform.Random.csproj
+++ b/csharp/Platform.Random/Platform.Random.csproj
@@ -4,7 +4,7 @@
     <Description>LinksPlatform's Platform.Random Class Library</Description>
     <Copyright>Konstantin Diachenko</Copyright>
     <AssemblyTitle>Platform.Random</AssemblyTitle>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <Authors>Konstantin Diachenko</Authors>
     <TargetFramework>net8</TargetFramework>
     <AssemblyName>Platform.Random</AssemblyName>
@@ -23,7 +23,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <LangVersion>latest</LangVersion>
-    <PackageReleaseNotes>Update target framework from net7 to net8.</PackageReleaseNotes>
+    <PackageReleaseNotes>Replace custom Random instance with Random.Shared from .NET 6+ for improved thread safety and performance.</PackageReleaseNotes>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/csharp/Platform.Random/RandomHelpers.cs
+++ b/csharp/Platform.Random/RandomHelpers.cs
@@ -7,9 +7,9 @@ namespace Platform.Random
     public static class RandomHelpers
     {
         /// <summary>
-        /// <para>Returns the pseudorandom number generator that is using the time of the first access to this field as seed.</para>
-        /// <para>Возвращает генератор псевдослучайных чисел использующий в качестве seed время первого обращения к этому полю.</para>
+        /// <para>Returns the shared, thread-safe pseudorandom number generator from .NET 6+.</para>
+        /// <para>Возвращает разделяемый, потокобезопасный генератор псевдослучайных чисел из .NET 6+.</para>
         /// </summary>
-        public static readonly System.Random Default = new System.Random(System.DateTime.UtcNow.Ticks.GetHashCode());
+        public static System.Random Default => System.Random.Shared;
     }
 }


### PR DESCRIPTION
## Summary
- Replaced custom `Random` instance using `DateTime.UtcNow.Ticks.GetHashCode()` seed with `Random.Shared` from .NET 6+
- Updated documentation comments to reflect the thread-safe nature of `Random.Shared`
- Incremented package version to 0.4.0 for next release
- Updated package release notes

## Benefits
- **Thread Safety**: `Random.Shared` provides built-in thread safety, eliminating potential issues with concurrent access
- **Performance**: Uses a more efficient implementation optimized for shared usage
- **Modern .NET**: Leverages the recommended approach introduced in .NET 6 for shared random number generation
- **Consistency**: Ensures consistent random number generation across the application

## Test Results
All existing tests pass with the new implementation:
- `DefaultFieldTest` - Verifies the Default field is not null
- `NextUInt64Test` - Verifies random UInt64 generation with ranges
- `NextBooleanTest` - Verifies random boolean generation

The change maintains backward compatibility while providing the benefits of the modern .NET 6+ approach.

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #53